### PR TITLE
Make DateTime structure public

### DIFF
--- a/CBLParseISO8601Date.podspec
+++ b/CBLParseISO8601Date.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CBLParseISO8601Date"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "An ISO-8601 date parser using C functions from SQLite."
   s.homepage     = "https://github.com/GateGuru/CBLParseISO8601Date"
   s.description  = <<-DESC
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
                    DESC
   s.license      = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.author       = { "Jens Alfke" => "http://jens.mooseyard.com/" }
-  s.source       = { :git => "https://github.com/GateGuru/CBLParseISO8601Date.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/GateGuru/CBLParseISO8601Date.git", :tag => #{s.version}" }
   s.source_files = 'Code'
 end

--- a/Code/CBLParseDate.c
+++ b/Code/CBLParseDate.c
@@ -60,33 +60,14 @@
 
 #include "CBLParseDate.h"
 
-#include <stdint.h>
 #include <stdarg.h>
 #include <ctype.h>
 #include <math.h>
 
 typedef uint8_t u8;
-typedef int64_t sqlite3_int64;
 
 #define sqlite3Isdigit isdigit
 #define sqlite3Isspace isspace
-
-
-/*
- ** A structure for holding a single date and time.
- */
-typedef struct DateTime DateTime;
-struct DateTime {
-    sqlite3_int64 iJD; /* The julian day number times 86400000 */
-    int Y, M, D;       /* Year, month, and day */
-    int h, m;          /* Hour and minutes */
-    int tz;            /* Timezone offset in minutes */
-    double s;          /* Seconds */
-    char validYMD;     /* True (1) if Y,M,D are valid */
-    char validHMS;     /* True (1) if h,m,s are valid */
-    char validJD;      /* True (1) if iJD is valid */
-    char validTZ;      /* True (1) if tz is valid */
-};
 
 
 /*
@@ -310,11 +291,16 @@ static int parseYyyyMmDd(const char *zDate, DateTime *p){
     return 0;
 }
 
-// Here's the main public function.
+// Public function.
 double CBLParseISO8601Date(const char* zDate) {
     DateTime x;
     if (parseYyyyMmDd(zDate,&x))
         return NAN;
     computeJD(&x);
     return x.iJD/1000.0 - 210866760000.0;
+}
+
+// Public function.
+int CBLParseISO8601DateTime(const char* zDate, DateTime *p) {
+    return (parseYyyyMmDd(zDate,p) ? 1 : 0);
 }

--- a/Code/CBLParseDate.h
+++ b/Code/CBLParseDate.h
@@ -9,8 +9,33 @@
 #ifndef CouchbaseLite_CBLParseDate_h
 #define CouchbaseLite_CBLParseDate_h
 
+#include <stdint.h>
+
+typedef int64_t sqlite3_int64;
+
 /** Parses a C string as an ISO-8601 date-time, returning a UNIX timestamp (number of seconds
     since 1/1/1970), or a NAN if the string is not valid. */
 double CBLParseISO8601Date(const char* dateStr);
+
+/*
+ ** A structure for holding a single date and time.
+ */
+typedef struct DateTime DateTime;
+struct DateTime {
+    sqlite3_int64 iJD; /* The julian day number times 86400000 */
+    int Y, M, D;       /* Year, month, and day */
+    int h, m;          /* Hour and minutes */
+    int tz;            /* Timezone offset in minutes */
+    double s;          /* Seconds */
+    char validYMD;     /* True (1) if Y,M,D are valid */
+    char validHMS;     /* True (1) if h,m,s are valid */
+    char validJD;      /* True (1) if iJD is valid */
+    char validTZ;      /* True (1) if tz is valid */
+};
+
+/** Parses a C string as an ISO-8601 date-time into the DateTime structure
+ ** and return 0 on success and 1 if the input string is not a well-formed date.
+ */
+int CBLParseISO8601DateTime(const char* zDate, DateTime *dateTime);
 
 #endif


### PR DESCRIPTION
I need to parse time zone from ISO8601 string but your structure DateTime isn't public so I move part of code to public and change spec version.

p.s. thanks for this repo.